### PR TITLE
options

### DIFF
--- a/packages/gelato-login/src/index.ts
+++ b/packages/gelato-login/src/index.ts
@@ -23,6 +23,11 @@ export interface LoginConfig {
   };
 }
 
+export interface LoginOptions {
+web3AuthNetwork: 'testnet' | 'cyan',
+client_id:string
+}
+
 export class GelatoLogin {
   protected _chainId: number;
   protected _web3Auth: Web3Auth | null = null;
@@ -46,9 +51,9 @@ export class GelatoLogin {
     };
   }
 
-  async init(): Promise<void> {
+  async init(loginOptions:LoginOptions): Promise<void> {
     const web3Auth = new Web3Auth({
-      clientId: CLIENT_ID,
+      clientId: loginOptions.client_id,
       chainConfig: {
         chainNamespace: CHAIN_NAMESPACES.EIP155,
         chainId: ethers.utils.hexValue(this._chainId),
@@ -60,7 +65,7 @@ export class GelatoLogin {
         loginMethodsOrder: ["google"],
         defaultLanguage: "en",
       },
-      web3AuthNetwork: "cyan",
+      web3AuthNetwork: loginOptions.web3AuthNetwork,
     });
 
     const openloginAdapter = new OpenloginAdapter({

--- a/packages/gelato-smart-login/src/index.ts
+++ b/packages/gelato-smart-login/src/index.ts
@@ -2,7 +2,7 @@ import {
   GelatoSmartWallet,
   SmartWalletConfig,
 } from "@gelatonetwork/account-abstraction";
-import { GelatoLogin, LoginConfig } from "@gelatonetwork/login";
+import { GelatoLogin, LoginConfig,LoginOptions } from "@gelatonetwork/login";
 import { SafeEventEmitterProvider } from "@web3auth/base";
 import { GelatoRelay } from "@gelatonetwork/relay-sdk";
 
@@ -20,14 +20,14 @@ export class GelatoSmartLogin extends GelatoLogin {
     this.#apiKey = smartWalletConfig.apiKey;
   }
 
-  async init(): Promise<void> {
+  async init(loginOptions:LoginOptions): Promise<void> {
     const isNetworkSupported = await this.#gelatoRelay.isNetworkSupported(
       this._chainId
     );
     if (!isNetworkSupported) {
       throw new Error(`Chain Id [${this._chainId}] is not supported`);
     }
-    await super.init();
+    await super.init(loginOptions);
     if (this._web3Auth?.provider) {
       await this._initializeSmartWallet();
     }


### PR DESCRIPTION
The web3Auth client_id and webAuthNetwork are hardcoded, I've included in this PR the ability to pass both parameters.

```
export interface LoginOptions {
web3AuthNetwork: 'testnet' | 'cyan',
client_id:string
}
```